### PR TITLE
TRITON-2453 sdc-fwrule parsing errors generate wrong error message

### DIFF
--- a/deps/fw/node_modules/fwrule/index.js
+++ b/deps/fw/node_modules/fwrule/index.js
@@ -21,6 +21,7 @@
  * CDDL HEADER END
  *
  * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ * Copyright 2024 MNX Cloud, Inc.
  *
  *
  * firewall rule parser: entry point
@@ -192,13 +193,14 @@ parser.yy.parseError = function parseError(_, details) {
         throw err;
     }
 
-    if (details.text === '') {
-        err = new validators.InvalidParamError('rule',
-            'Error at character 0: \'\', expected: \'FROM\', found: '
-            + 'empty string');
-        err.details = details;
-        throw err;
-    }
+    // Delete me
+    // if (details.text === '') {
+        // err = new validators.InvalidParamError('rule',
+            // 'Error at character 0: \'\', expected: \'FROM\', found: '
+            // + 'empty string');
+        // err.details = details;
+        // throw err;
+    // }
 
     err = new validators.InvalidParamError('rule',
         'Error at character %d: \'%s\', expected: %s, found: %s',

--- a/deps/fw/node_modules/fwrule/index.js
+++ b/deps/fw/node_modules/fwrule/index.js
@@ -193,15 +193,6 @@ parser.yy.parseError = function parseError(_, details) {
         throw err;
     }
 
-    // Delete me
-    // if (details.text === '') {
-        // err = new validators.InvalidParamError('rule',
-            // 'Error at character 0: \'\', expected: \'FROM\', found: '
-            // + 'empty string');
-        // err.details = details;
-        // throw err;
-    // }
-
     err = new validators.InvalidParamError('rule',
         'Error at character %d: \'%s\', expected: %s, found: %s',
         details.loc.last_column,

--- a/deps/fw/package.json
+++ b/deps/fw/package.json
@@ -16,7 +16,7 @@
     "clone": "0.1.4",
     "cmdln": "4.1.1",
     "extsprintf": "1.0.2",
-    "fwrule": "2.1.0",
+    "fwrule": "2.1.1",
     "ip6addr": "0.2.2",
     "mkdirp": "0.3.4",
     "uuid": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "firewaller",
     "description": "Triton Data Center firewalling agent",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "author": "Joyent (joyent.com)",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
This should be fine as-is, but the build will *also* `npm install fwrule` so it fails because version 2.1.1 hasn't been published yet (pending TritonDataCenter/sdc-fwrule#5). Once it is published, I'll proceed with this PR.

Maybe it should be removed from `package.json`, but I don't want to make a bigger problem for myself later on so I'll leave that alone for now.