### PR TITLE
TRITON-2470 fs-ext version 2.1.1 doesn't work with sdc-firewaller-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "firewaller",
     "description": "Triton Data Center firewalling agent",
-    "version": "1.6.2",
-    "author": "Joyent (joyent.com)",
+    "version": "1.6.3",
+    "author": "Triton DataCenter (tritondatacenter.com)",
     "private": true,
     "dependencies": {
         "assert-plus": "1.0.0",
@@ -11,7 +11,7 @@
         "clone": "1.0.2",
         "cueball": "2.10.0",
         "fast-messages": "2.0.0",
-        "fs-ext": "^2.0.0",
+        "fs-ext": "2.0.0",
         "fw": "./deps/fw",
         "jsprim": "2.0.0",
         "restify": "4.3.4",


### PR DESCRIPTION
npm updated fs-ext to 2.1.1 and it breaks sdc-firewaller-agent.  Prior builds used 2.0.0, so now I'd like to fix it to stay on 2.0.0